### PR TITLE
Use injectable API base URL

### DIFF
--- a/lib/core/config/app_config.dart
+++ b/lib/core/config/app_config.dart
@@ -1,0 +1,6 @@
+class AppConfig {
+  final String apiBaseUrl;
+
+  const AppConfig({required this.apiBaseUrl});
+}
+

--- a/lib/core/services/auth_service.dart
+++ b/lib/core/services/auth_service.dart
@@ -3,12 +3,13 @@ import 'dart:convert';
 import '../models/user.dart';
 
 class AuthService {
-  static const String _baseUrl =
-      'https://api.meditrack.com'; // Replace with actual URL
+  final String baseUrl;
+
+  AuthService({required this.baseUrl});
 
   Future<AuthResult> login(String email, String password) async {
     final response = await http.post(
-      Uri.parse('$_baseUrl/auth/login'),
+      Uri.parse('$baseUrl/auth/login'),
       headers: {'Content-Type': 'application/json'},
       body: jsonEncode({
         'email': email,
@@ -27,7 +28,7 @@ class AuthService {
 
   Future<AuthResult> signup(String email, String password, String name) async {
     final response = await http.post(
-      Uri.parse('$_baseUrl/auth/signup'),
+      Uri.parse('$baseUrl/auth/signup'),
       headers: {'Content-Type': 'application/json'},
       body: jsonEncode({
         'email': email,
@@ -47,7 +48,7 @@ class AuthService {
 
   Future<void> forgotPassword(String email) async {
     final response = await http.post(
-      Uri.parse('$_baseUrl/auth/forgot-password'),
+      Uri.parse('$baseUrl/auth/forgot-password'),
       headers: {'Content-Type': 'application/json'},
       body: jsonEncode({'email': email}),
     );
@@ -71,7 +72,7 @@ class AuthService {
 
   Future<String> refreshToken(String refreshToken) async {
     final response = await http.post(
-      Uri.parse('$_baseUrl/auth/refresh'),
+      Uri.parse('$baseUrl/auth/refresh'),
       headers: {'Content-Type': 'application/json'},
       body: jsonEncode({'refreshToken': refreshToken}),
     );

--- a/lib/core/services/medication_service.dart
+++ b/lib/core/services/medication_service.dart
@@ -3,7 +3,9 @@ import 'dart:convert';
 import '../models/medication.dart';
 
 class MedicationService {
-  static const String _baseUrl = 'https://api.meditrack.com'; // Replace with actual URL
+  final String baseUrl;
+
+  MedicationService({required this.baseUrl});
 
   Future<List<Medication>> getMedications() async {
     // Mock data for now

--- a/lib/ui/auth/forgot_password_page.dart
+++ b/lib/ui/auth/forgot_password_page.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-import '../../core/services/auth_service.dart';
+import '../../core/providers/providers.dart';
 import '../../core/theme/app_theme.dart';
 
 class ForgotPasswordPage extends ConsumerStatefulWidget {
@@ -31,7 +31,9 @@ class _ForgotPasswordPageState extends ConsumerState<ForgotPasswordPage> {
       });
 
       try {
-        await AuthService().forgotPassword(_emailController.text.trim());
+        await ref
+            .read(authServiceProvider)
+            .forgotPassword(_emailController.text.trim());
         setState(() {
           _emailSent = true;
           _isLoading = false;

--- a/lib/ui/tabs/calendar_page.dart
+++ b/lib/ui/tabs/calendar_page.dart
@@ -5,7 +5,6 @@ import 'package:intl/intl.dart';
 
 import '../../core/providers/providers.dart';
 import '../../core/models/medication.dart';
-import '../../core/services/medication_service.dart';
 import '../widgets/dose_card.dart';
 
 class CalendarPage extends ConsumerStatefulWidget {
@@ -33,7 +32,9 @@ class _CalendarPageState extends ConsumerState<CalendarPage> {
     });
 
     try {
-      final doses = await MedicationService().getDosesForDate(day);
+      final doses = await ref
+          .read(medicationServiceProvider)
+          .getDosesForDate(day);
       setState(() {
         _selectedDayDoses = doses;
         _isLoadingDoses = false;


### PR DESCRIPTION
## Summary
- centralize API base URL in new `AppConfig`
- inject base URL into `AuthService` and `MedicationService`
- wire services through providers and update pages to use injected services

## Testing
- `dart format lib/core/config/app_config.dart lib/core/services/auth_service.dart lib/core/services/medication_service.dart lib/core/providers/providers.dart lib/ui/auth/forgot_password_page.dart lib/ui/tabs/calendar_page.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e285fe288324b5f608eb48924bc6