### PR TITLE
chore: consolidate notification imports

### DIFF
--- a/lib/core/services/notification_service.dart
+++ b/lib/core/services/notification_service.dart
@@ -1,11 +1,19 @@
-import 'package:flutter_local_notifications/flutter_local_notifications.dart';
-import 'package:shared_preferences/shared_preferences.dart';
-import 'package:timezone/timezone.dart' as tz;
 import 'package:flutter_local_notifications/flutter_local_notifications.dart'
     show
-        ScheduledNotificationDateInterpretation,
+        AndroidInitializationSettings,
+        AndroidNotificationDetails,
+        AndroidScheduleMode,
         DateTimeComponents,
-        AndroidScheduleMode;
+        DarwinInitializationSettings,
+        DarwinNotificationDetails,
+        FlutterLocalNotificationsPlugin,
+        IOSFlutterLocalNotificationsPlugin,
+        Importance,
+        InitializationSettings,
+        NotificationDetails,
+        Priority;
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:timezone/timezone.dart' as tz;
 
 class NotificationService {
   static final NotificationService _instance = NotificationService._internal();


### PR DESCRIPTION
## Summary
- consolidate flutter_local_notifications imports in NotificationService into one show-import

## Testing
- `dart format lib/core/services/notification_service.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ef6e9a78832494cede7dc4d0d554