### PR TITLE
Use provider for dose retrieval

### DIFF
--- a/lib/core/providers/providers.dart
+++ b/lib/core/providers/providers.dart
@@ -26,6 +26,12 @@ final medicationServiceProvider = Provider<MedicationService>((ref) {
   return MedicationService(baseUrl: config.apiBaseUrl);
 });
 
+final dosesForDateProvider =
+    FutureProvider.family<List<Dose>, DateTime>((ref, date) async {
+  final service = ref.watch(medicationServiceProvider);
+  return service.getDosesForDate(date);
+});
+
 // Theme Provider
 final themeModeProvider = StateNotifierProvider<ThemeModeNotifier, ThemeMode>((ref) {
   return ThemeModeNotifier();

--- a/lib/ui/tabs/calendar_page.dart
+++ b/lib/ui/tabs/calendar_page.dart
@@ -32,9 +32,7 @@ class _CalendarPageState extends ConsumerState<CalendarPage> {
     });
 
     try {
-      final doses = await ref
-          .read(medicationServiceProvider)
-          .getDosesForDate(day);
+      final doses = await ref.read(dosesForDateProvider(day).future);
       setState(() {
         _selectedDayDoses = doses;
         _isLoadingDoses = false;


### PR DESCRIPTION
## Summary
- add `dosesForDateProvider` wrapping `MedicationService.getDosesForDate`
- refactor calendar page to load doses via new provider

## Testing
- `dart format lib/core/providers/providers.dart lib/ui/tabs/calendar_page.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f00359008324a3c04e9180821759