### PR TITLE
Expose medication reload method and trigger on refresh

### DIFF
--- a/lib/core/providers/providers.dart
+++ b/lib/core/providers/providers.dart
@@ -183,6 +183,11 @@ class MedicationNotifier extends StateNotifier<MedicationState> {
     }
   }
 
+  /// Public method to refresh medications and upcoming doses
+  Future<void> reload() async {
+    await _loadMedications();
+  }
+
   Future<bool> addMedication(Medication medication) async {
     try {
       final newMedication = await _medicationService.addMedication(medication);
@@ -199,7 +204,7 @@ class MedicationNotifier extends StateNotifier<MedicationState> {
   Future<void> markDoseTaken(String doseId) async {
     try {
       await _medicationService.markDoseTaken(doseId);
-      await _loadMedications(); // Refresh data
+      await reload(); // Refresh data
     } catch (e) {
       state = state.copyWith(error: e.toString());
     }
@@ -208,7 +213,7 @@ class MedicationNotifier extends StateNotifier<MedicationState> {
   Future<void> markDoseSkipped(String doseId) async {
     try {
       await _medicationService.markDoseSkipped(doseId);
-      await _loadMedications(); // Refresh data
+      await reload(); // Refresh data
     } catch (e) {
       state = state.copyWith(error: e.toString());
     }

--- a/lib/ui/tabs/home_page.dart
+++ b/lib/ui/tabs/home_page.dart
@@ -43,7 +43,7 @@ class HomePage extends ConsumerWidget {
       ),
       body: RefreshIndicator(
         onRefresh: () async {
-          // Refresh data
+          await ref.read(medicationProvider.notifier).reload();
         },
         child: medicationState.isLoading
             ? const Center(child: CircularProgressIndicator())


### PR DESCRIPTION
## Summary
- expose a public `reload` method on `MedicationNotifier` to refresh medication and dose data
- refresh home page data by invoking `reload` from the `RefreshIndicator`

## Testing
- `dart format lib/core/providers/providers.dart lib/ui/tabs/home_page.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f0aca6808324899fd3da4eeef878