### PR TITLE
chore: delegate repository config to settings

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,10 +1,3 @@
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
-}
-
 val newBuildDir: Directory =
     rootProject.layout.buildDirectory
         .dir("../../build")


### PR DESCRIPTION
## Summary
- remove top-level repository block from Android Gradle build so repos are configured in settings

## Testing
- `flutter run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f92b958083249c2aa7ed06d2a3cb