### PR TITLE
chore(android): prefer settings repositories

### DIFF
--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -29,7 +29,7 @@ plugins {
 }
 
 dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
## Summary
- prefer repositories defined in settings.gradle

## Testing
- `flutter clean` *(fails: command not found)*
- `flutter run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8fa2d53b08324b3d297ae09108cd3