### PR TITLE
Track microphone permission state in voice input

### DIFF
--- a/lib/ui/medication/voice_input_page.dart
+++ b/lib/ui/medication/voice_input_page.dart
@@ -17,6 +17,7 @@ class _VoiceInputPageState extends ConsumerState<VoiceInputPage>
   final SpeechToText _speechToText = SpeechToText();
   String _wordsSpoken = "";
   double _confidenceLevel = 0;
+  bool _hasPermission = false;
 
   late AnimationController _pulseController;
   late AnimationController _waveController;
@@ -46,14 +47,17 @@ class _VoiceInputPageState extends ConsumerState<VoiceInputPage>
 
   void _initSpeech() async {
     await _speechToText.initialize();
+    _hasPermission = await _speechToText.hasPermission();
     setState(() {});
   }
 
   void _startListening() async {
-    if (!_speechToText.hasPermission) {
+    _hasPermission = await _speechToText.hasPermission();
+    if (!_hasPermission) {
       final available = await _speechToText.initialize();
+      _hasPermission = await _speechToText.hasPermission();
       setState(() {});
-      if (!_speechToText.hasPermission) {
+      if (!_hasPermission) {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('Microphone permission denied')),
         );
@@ -169,7 +173,7 @@ class _VoiceInputPageState extends ConsumerState<VoiceInputPage>
                     Text(
                       _speechToText.isListening
                           ? 'Listening...'
-                          : !_speechToText.hasPermission
+                          : !_hasPermission
                               ? 'Microphone permission denied'
                               : _speechToText.isAvailable
                                   ? 'Tap the microphone to start'


### PR DESCRIPTION
## Summary
- add `_hasPermission` state to cache microphone permission
- refresh permission before listening and guard against denial
- show status text based on stored permission value

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8fbccacc883249a1c6b74b7559efc