### PR TITLE
chore: bump Kotlin plugin to 2.1.0

### DIFF
--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -25,7 +25,7 @@ plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
     // Not applied here; the :app module applies them
     id("com.android.application") version "8.7.0" apply(false)
-    id("org.jetbrains.kotlin.android") version "1.9.24" apply(false)
+    id("org.jetbrains.kotlin.android") version "2.1.0" apply(false)
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
## Summary
- update Android project to Kotlin plugin 2.1.0

## Testing
- `gradle assembleDebug` *(fails: `flutter.sdk` not set)*

------
https://chatgpt.com/codex/tasks/task_e_68a8fca176708324bfc0ae56ee889b14