### PR TITLE
Use awaited permission getter in voice input page

### DIFF
--- a/lib/ui/medication/voice_input_page.dart
+++ b/lib/ui/medication/voice_input_page.dart
@@ -47,15 +47,15 @@ class _VoiceInputPageState extends ConsumerState<VoiceInputPage>
 
   void _initSpeech() async {
     await _speechToText.initialize();
-    _hasPermission = await _speechToText.hasPermission();
+    _hasPermission = await _speechToText.hasPermission;
     setState(() {});
   }
 
   void _startListening() async {
-    _hasPermission = await _speechToText.hasPermission();
+    _hasPermission = await _speechToText.hasPermission;
     if (!_hasPermission) {
       final available = await _speechToText.initialize();
-      _hasPermission = await _speechToText.hasPermission();
+      _hasPermission = await _speechToText.hasPermission;
       setState(() {});
       if (!_hasPermission) {
         ScaffoldMessenger.of(context).showSnackBar(


### PR DESCRIPTION
## Summary
- update speech permission checks to use awaited `hasPermission` getter

## Testing
- `flutter analyze` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a8fe7973948324b81ed0d86aa94632