### PR TITLE
Refactor medication service to GraphQL

### DIFF
--- a/lib/core/models/dashboard_data.dart
+++ b/lib/core/models/dashboard_data.dart
@@ -1,0 +1,15 @@
+import 'medication.dart';
+
+class DashboardData {
+  final List<Medication> medications;
+  final List<Dose> upcomingDoses;
+  final List<Dose> missedDoses;
+  final List<Medication> refillAlerts;
+
+  DashboardData({
+    this.medications = const [],
+    this.upcomingDoses = const [],
+    this.missedDoses = const [],
+    this.refillAlerts = const [],
+  });
+}

--- a/lib/ui/medication/confirm_page.dart
+++ b/lib/ui/medication/confirm_page.dart
@@ -386,11 +386,10 @@ class _ConfirmPageState extends ConsumerState<ConfirmPage> {
       );
 
       // Add medication via provider
-      final success =
-          await ref.read(medicationProvider.notifier).addMedication(medication);
+      final notifier = ref.read(medicationProvider.notifier);
+      final success = await notifier.addMedication(medication);
 
       if (success && mounted) {
-        // Show success message
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text('${medication.name} added successfully!'),
@@ -398,9 +397,16 @@ class _ConfirmPageState extends ConsumerState<ConfirmPage> {
             behavior: SnackBarBehavior.floating,
           ),
         );
-
-        // Navigate back to home
         context.go('/');
+      } else if (mounted) {
+        final error = ref.read(medicationProvider).error ?? 'Unknown error';
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Error adding medication: $error'),
+            backgroundColor: AppTheme.errorColor,
+            behavior: SnackBarBehavior.floating,
+          ),
+        );
       }
     } catch (e) {
       if (mounted) {

--- a/lib/ui/medication/scan_page.dart
+++ b/lib/ui/medication/scan_page.dart
@@ -2,18 +2,20 @@ import 'package:flutter/material.dart';
 import 'package:camera/camera.dart';
 import 'package:go_router/go_router.dart';
 import 'package:image_picker/image_picker.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/theme/app_theme.dart';
+import '../../core/providers/providers.dart';
 import '../widgets/cylindrical_overlay.dart';
 
-class ScanPage extends StatefulWidget {
+class ScanPage extends ConsumerStatefulWidget {
   const ScanPage({super.key});
 
   @override
-  State<ScanPage> createState() => _ScanPageState();
+  ConsumerState<ScanPage> createState() => _ScanPageState();
 }
 
-class _ScanPageState extends State<ScanPage> {
+class _ScanPageState extends ConsumerState<ScanPage> {
   CameraController? _controller;
   bool _isInitialized = false;
   bool _isRecording = false;
@@ -453,42 +455,46 @@ class _ScanPageState extends State<ScanPage> {
     }
   }
 
-  void _processVideo(String videoPath) {
-    // Simulate processing delay
+  void _processVideo(String videoPath) async {
     _showProcessingDialog();
-    
-    Future.delayed(const Duration(seconds: 3), () {
-      Navigator.of(context).pop(); // Close processing dialog
-      
-      // Navigate to confirmation with mock data
-      context.go('/medication/confirm', extra: {
-        'name': 'Lisinopril',
-        'dosage': 10.0,
-        'unit': 'mg',
-        'form': 'tablet',
-        'confidence': 0.92,
-        'imagePath': videoPath,
-      });
-    });
+    try {
+      final data =
+          await ref.read(medicationServiceProvider).parseLabel(videoPath);
+      if (!mounted) return;
+      Navigator.of(context).pop();
+      context.go('/medication/confirm', extra: data);
+    } catch (e) {
+      if (mounted) {
+        Navigator.of(context).pop();
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Error parsing label: $e'),
+            backgroundColor: AppTheme.errorColor,
+          ),
+        );
+      }
+    }
   }
 
-  void _processImage(String imagePath) {
-    // Simulate processing delay
+  void _processImage(String imagePath) async {
     _showProcessingDialog();
-    
-    Future.delayed(const Duration(seconds: 2), () {
-      Navigator.of(context).pop(); // Close processing dialog
-      
-      // Navigate to confirmation with mock data
-      context.go('/medication/confirm', extra: {
-        'name': 'Metformin',
-        'dosage': 500.0,
-        'unit': 'mg',
-        'form': 'tablet',
-        'confidence': 0.87,
-        'imagePath': imagePath,
-      });
-    });
+    try {
+      final data =
+          await ref.read(medicationServiceProvider).parseLabel(imagePath);
+      if (!mounted) return;
+      Navigator.of(context).pop();
+      context.go('/medication/confirm', extra: data);
+    } catch (e) {
+      if (mounted) {
+        Navigator.of(context).pop();
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Error parsing label: $e'),
+            backgroundColor: AppTheme.errorColor,
+          ),
+        );
+      }
+    }
   }
 
   void _showProcessingDialog() {

--- a/lib/ui/tabs/home_page.dart
+++ b/lib/ui/tabs/home_page.dart
@@ -71,7 +71,28 @@ class HomePage extends ConsumerWidget {
                       ],
                     ),
                     const SizedBox(height: 8),
-                    _buildUpcomingDoses(context, medicationState.upcomingDoses),
+                    _buildDoseList(context, medicationState.upcomingDoses),
+
+                    if (medicationState.missedDoses.isNotEmpty) ...[
+                      const SizedBox(height: 24),
+                      Text(
+                        'Missed Doses',
+                        style: Theme.of(context).textTheme.titleLarge,
+                      ),
+                      const SizedBox(height: 8),
+                      _buildDoseList(context, medicationState.missedDoses),
+                    ],
+
+                    if (medicationState.refillAlerts.isNotEmpty) ...[
+                      const SizedBox(height: 24),
+                      Text(
+                        'Refill Alerts',
+                        style: Theme.of(context).textTheme.titleLarge,
+                      ),
+                      const SizedBox(height: 8),
+                      _buildMedicationsList(
+                          context, medicationState.refillAlerts),
+                    ],
 
                     const SizedBox(height: 24),
 
@@ -193,7 +214,7 @@ class HomePage extends ConsumerWidget {
     );
   }
 
-  Widget _buildUpcomingDoses(BuildContext context, List<Dose> doses) {
+  Widget _buildDoseList(BuildContext context, List<Dose> doses) {
     if (doses.isEmpty) {
       return Card(
         child: Padding(


### PR DESCRIPTION
## Summary
- use GraphQL for medication mutations and queries
- surface dashboard data including missed doses and refill alerts
- handle medication label parsing through GraphQL and show errors to users

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a92f8864a48324b92bc84071310e85