### PR TITLE
feat: make API endpoint configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,26 @@
 # meditrack_flutter
 
 A new Flutter project.
+
+## Configuring the API endpoint
+
+The app picks a default GraphQL server URL based on the `ENV` value
+supplied via `--dart-define` when running the app:
+
+| ENV value    | API base URL                         |
+|--------------|--------------------------------------|
+| development  | http://192.168.50.5:8000/graphql     |
+| emulator     | http://10.0.2.2:8000/graphql         |
+| production   | https://midtrack.example.com/graphql |
+
+To point the app to a specific server, override the URL directly:
+
+```bash
+flutter run --dart-define=API_BASE_URL=http://<your-ip>:8000/graphql
+```
+
+You can also select one of the preset environments:
+
+```bash
+flutter run --dart-define=ENV=emulator
+```

--- a/lib/core/config/app_config.dart
+++ b/lib/core/config/app_config.dart
@@ -1,6 +1,26 @@
 class AppConfig {
   final String apiBaseUrl;
 
-  const AppConfig({required this.apiBaseUrl});
+  const AppConfig._({required this.apiBaseUrl});
+
+  factory AppConfig() {
+    const override =
+        String.fromEnvironment('API_BASE_URL', defaultValue: '');
+    if (override.isNotEmpty) {
+      return AppConfig._(apiBaseUrl: override);
+    }
+
+    const env = String.fromEnvironment('ENV', defaultValue: 'development');
+    switch (env) {
+      case 'emulator':
+        return AppConfig._(apiBaseUrl: 'http://10.0.2.2:8000/graphql');
+      case 'production':
+        return AppConfig._(
+            apiBaseUrl: 'https://midtrack.example.com/graphql');
+      case 'development':
+      default:
+        return AppConfig._(apiBaseUrl: 'http://192.168.50.5:8000/graphql');
+    }
+  }
 }
 

--- a/lib/core/providers/providers.dart
+++ b/lib/core/providers/providers.dart
@@ -15,7 +15,7 @@ import '../services/secure_storage.dart';
 
 // App Config Provider
 final appConfigProvider = Provider<AppConfig>((ref) {
-  return const AppConfig(apiBaseUrl: 'http://192.168.50.5:8000/graphql');
+  return AppConfig();
 });
 
 // Service Providers


### PR DESCRIPTION
## Summary
- add environment-aware AppConfig with defaults for dev, emulator, and production
- wire providers to new AppConfig
- document overriding API endpoint via dart-define

## Testing
- `dart format lib/core/config/app_config.dart lib/core/providers/providers.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a94118ef40832495070e8afacc5cf8